### PR TITLE
Refactor multer middleware exports

### DIFF
--- a/server/middlewares/multer.middleware.mjs
+++ b/server/middlewares/multer.middleware.mjs
@@ -1,4 +1,6 @@
 import multer from "multer";
 
-const multerUpload = multer({ dest: "uploads/" });
-const avatarUpload = multerUpload.fields([{ name: "avatar", maxCount: 5 }]);
+export const multerUpload = multer({ dest: "uploads/" });
+export const avatarUpload = multerUpload.fields([
+  { name: "avatar", maxCount: 5 },
+]);


### PR DESCRIPTION
This pull request refactors the multer middleware exports. The `multerUpload` and `avatarUpload` exports have been updated to use the `export` keyword, allowing them to be imported and used in other modules.