### PR TITLE
Refactor start script to use node instead of nodemon

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "start": "nodemon server.mjs",
+    "start": "node server.mjs",
+    "dev": "nodemon server.mjs",
     "swagger-autogen": "node swaggerConfig.mjs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -63,12 +63,12 @@ const httpServer = http.createServer(app);
 // connect soket io
 socket(httpServer);
 
-httpServer.listen(PORT, () => {
+httpServer.listen(PORT, "0.0.0.0", () => {
   console.log(`Server running in ${process.env.NODE_ENV} mode on port ${PORT}`);
 });
 
 process.on("SIGTERM", () => {
-  server.close(() => {
+  httpServer.close(() => {
     logger.info("Process terminated");
   });
 });


### PR DESCRIPTION
This pull request updates the start script in the package.json file to use the "node" command instead of "nodemon". This change ensures that the server is started using the regular Node.js runtime instead of nodemon, which is a development tool. Additionally, the "dev" script has been added to the package.json file, which uses nodemon to start the server in development mode.